### PR TITLE
chore: CODEOWNERS team ownership sweep

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 #          ***  Ideally this will be defined for a healthy, well-maintained repo  ***
 #          **************************************************************************
 # FILE PATTERN                              OWNER(S)
-*                                           @NONE
+*                                           @mention-me/sre
 
 # SECTION: Owner(s) for specific directories
 # FILE PATTERN                              OWNER(S)


### PR DESCRIPTION
Standardise code ownership across the org.

Adds/normalises `CODEOWNERS` so every repo has a team-based `*` default owner and legacy/ghost team tokens are retired (Stage 3 of the teams/permissions rollout).

Auto-generated sweep.